### PR TITLE
Icon: deprecate icon_size

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -32,6 +32,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import Rsvg
 import cairo
 
+from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor
 from sugar3.util import LRU
 
@@ -343,6 +344,25 @@ class Icon(Gtk.Image):
         self._file = None
         self._alpha = 1.0
         self._scale = 1.0
+
+        if 'pixel_size' not in kwargs:
+            kwargs['pixel_size'] = style.STANDARD_ICON_SIZE
+
+        #FIXME: deprecate icon_size
+        if 'icon_size' in kwargs:
+            logging.warning("icon_size is deprecated. Use pixel_size instead.")
+            logging.debug(kwargs['icon_size'])
+
+            menu_sizes = (Gtk.IconSize.MENU, Gtk.IconSize.DND,
+                          Gtk.IconSize.SMALL_TOOLBAR, Gtk.IconSize.BUTTON)
+
+            if kwargs['icon_size'] in menu_sizes:
+                kwargs['pixel_size'] = style.MENU_ICON_SIZE
+
+            elif kwargs['icon_size'] == Gtk.IconSize.LARGE_TOOLBAR:
+                kwargs['pixel_size'] = style.STANDARD_ICON_SIZE
+
+            kwargs.pop('icon_size')
 
         GObject.GObject.__init__(self, **kwargs)
 

--- a/src/sugar3/graphics/style.py
+++ b/src/sugar3/graphics/style.py
@@ -114,6 +114,7 @@ SMALL_ICON_SIZE = zoom(55 * 0.5)
 MEDIUM_ICON_SIZE = zoom(55 * 1.5)
 LARGE_ICON_SIZE = zoom(55 * 2.0)
 XLARGE_ICON_SIZE = zoom(55 * 2.75)
+MENU_ICON_SIZE = zoom(33)
 
 settings = Gio.Settings('org.sugarlabs.font')
 FONT_SIZE = settings.get_double('default-size')


### PR DESCRIPTION
pixel_size should be always used now.

Adds a constant MENU_ICON_SIZE to cover the other sizes at settings.ini.

Adds a transformation to keep backwards compatibility for some
time. This will be removed in the future.
