### PR TITLE
Icon: deprecate icon_size

### DIFF
--- a/src/sugar3/graphics/icon.py
+++ b/src/sugar3/graphics/icon.py
@@ -32,6 +32,7 @@ from gi.repository import GdkPixbuf
 from gi.repository import Rsvg
 import cairo
 
+from sugar3.graphics import style
 from sugar3.graphics.xocolor import XoColor
 from sugar3.util import LRU
 
@@ -335,6 +336,10 @@ class Icon(Gtk.Image):
 
     __gtype_name__ = 'SugarIcon'
 
+    #FIXME: deprecate icon_size
+    _MENU_SIZES = (Gtk.IconSize.MENU, Gtk.IconSize.DND,
+                   Gtk.IconSize.SMALL_TOOLBAR, Gtk.IconSize.BUTTON)
+
     def __init__(self, **kwargs):
         self._buffer = _IconBuffer()
         # HACK: need to keep a reference to the path so it doesn't get garbage
@@ -343,6 +348,10 @@ class Icon(Gtk.Image):
         self._file = None
         self._alpha = 1.0
         self._scale = 1.0
+
+        #FIXME: deprecate icon_size
+        if 'icon_size' in kwargs:
+            logging.warning("icon_size is deprecated. Use pixel_size instead.")
 
         GObject.GObject.__init__(self, **kwargs)
 
@@ -362,10 +371,15 @@ class Icon(Gtk.Image):
         if self._buffer.file_name != self.props.file:
             self._buffer.file_name = self.props.file
 
+        #FIXME: deprecate icon_size
         if self.props.pixel_size == -1:
-            valid_, width, height = Gtk.icon_size_lookup(self.props.icon_size)
-        else:
-            width = height = self.props.pixel_size
+            if self.props.icon_size in self._MENU_SIZES:
+                self.props.pixel_size = style.MENU_ICON_SIZE
+            else:
+                self.props.pixel_size = style.STANDARD_ICON_SIZE
+
+        width = height = self.props.pixel_size
+
         if self._buffer.width != width or self._buffer.height != height:
             self._buffer.width = width
             self._buffer.height = height

--- a/src/sugar3/graphics/style.py
+++ b/src/sugar3/graphics/style.py
@@ -114,6 +114,7 @@ SMALL_ICON_SIZE = zoom(55 * 0.5)
 MEDIUM_ICON_SIZE = zoom(55 * 1.5)
 LARGE_ICON_SIZE = zoom(55 * 2.0)
 XLARGE_ICON_SIZE = zoom(55 * 2.75)
+MENU_ICON_SIZE = zoom(33)
 
 settings = Gio.Settings('org.sugarlabs.font')
 FONT_SIZE = settings.get_double('default-size')


### PR DESCRIPTION
pixel_size should be always used now.

Adds a constant MENU_ICON_SIZE to cover the other sizes at settings.ini.

Adds a transformation to keep backwards compatibility for some
time. This will be removed in the future.
