### PR TITLE
Add spent_time to metadata

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -753,6 +753,13 @@ class Activity(Window, Gtk.Container):
             self.metadata['buddies_id'] = json.dumps(buddies_dict.keys())
             self.metadata['buddies'] = json.dumps(self._get_buddies())
 
+        def get_last_launch():
+            return int(self.metadata['launch-times'].split(', ')[-1])
+
+        spent_time = int(time.time()) - get_last_launch()
+        previous_spent_time = int(self.metadata.get('spent_time', 0))
+        self.metadata['spent_time'] = spent_time + previous_spent_time
+
         preview = self.get_preview()
         if preview is not None:
             self.metadata['preview'] = dbus.ByteArray(preview)


### PR DESCRIPTION
spent_time is the time the user has spent on a particular activity
instance.  Each time the instance is resumed, the activity duration is
added to the previous one.
