### PR TITLE
Add spent-times to activity metadata

### DIFF
--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -794,6 +794,10 @@ class Activity(Window, Gtk.Container):
             self.metadata['buddies_id'] = json.dumps(buddies_dict.keys())
             self.metadata['buddies'] = json.dumps(self._get_buddies())
 
+        # Accumulate the last spent time.
+        if self._active:
+            self._update_spent_time(False)
+
         def set_last_value(values_list, new_value):
             if ', ' not in values_list:
                 return '%d' % new_value

--- a/src/sugar3/activity/activity.py
+++ b/src/sugar3/activity/activity.py
@@ -327,6 +327,8 @@ class Activity(Window, Gtk.Container):
         self.connect('delete-event', self.__delete_event_cb)
 
         self._active = False
+        self._active_time = None
+        self._spent_time = 0
         self._activity_id = handle.activity_id
         self.shared_activity = None
         self._join_id = None
@@ -366,6 +368,11 @@ class Activity(Window, Gtk.Container):
             else:
                 self._jobject.metadata['launch-times'] = \
                     str(int(time.time()))
+
+            if 'spent-times' in self._jobject.metadata:
+                self._jobject.metadata['spent-times'] += ', 0'
+            else:
+                self._jobject.metadata['spent-times'] = '0'
 
         self.shared_activity = None
         self._join_id = None
@@ -420,6 +427,7 @@ class Activity(Window, Gtk.Container):
         jobject.metadata['share-scope'] = SCOPE_PRIVATE
         jobject.metadata['icon-color'] = icon_color
         jobject.metadata['launch-times'] = str(int(time.time()))
+        jobject.metadata['spent-times'] = '0'
         jobject.file_path = ''
 
         # FIXME: We should be able to get an ID synchronously from the DS,
@@ -485,9 +493,17 @@ class Activity(Window, Gtk.Container):
     def get_active(self):
         return self._active
 
+    def _update_spent_time(self, active):
+        if active:
+            self._active_time = time.time()
+        else:
+            self._spent_time += time.time() - self._active_time
+            self._active_time = None
+
     def set_active(self, active):
         if self._active != active:
             self._active = active
+            self._update_spent_time(self._active)
             if not self._active and self._jobject:
                 self.save()
 
@@ -777,6 +793,16 @@ class Activity(Window, Gtk.Container):
         if buddies_dict:
             self.metadata['buddies_id'] = json.dumps(buddies_dict.keys())
             self.metadata['buddies'] = json.dumps(self._get_buddies())
+
+        def set_last_value(values_list, new_value):
+            if ', ' not in values_list:
+                return '%d' % new_value
+            else:
+                partial_list = ', '.join(values_list.split(', ')[:-1])
+                return partial_list + ', %d' % new_value
+
+        self.metadata['spent-times'] = set_last_value(
+            self.metadata['spent-times'], self._spent_time)
 
         preview = self.get_preview()
         if preview is not None:


### PR DESCRIPTION
spent-times is a comma-separated list with the times the user has spent
on a particular activity instance.  Each time the instance is resumed,
the activity duration is added to the list, measured in seconds.  The
time the activity is in the background is discriminated (ie. doesn't
added).  And internally, microseconds are used for the computation.
Example of an activity instance that has been resumed four times:

```
'110, 35, 12, 143'
```
